### PR TITLE
Added fallback for nonpower of 2 gifs. Adding white pixels at the edges.

### DIFF
--- a/Assets/Scripts/Runtime/Decode/GifCanvas.cs
+++ b/Assets/Scripts/Runtime/Decode/GifCanvas.cs
@@ -69,16 +69,19 @@ namespace ThreeDISevenZeroR.UnityGifDecoder
         /// <param name="height">New canvas height</param>
         public void SetSize(int width, int height)
         {
-            if (width != canvasWidth || height != canvasHeight)
+            int adjustedWidth = width + (4 - (width % 4)) % 4;
+            int adjustedHeight = height + (4 - (height % 4)) % 4;
+
+            if (adjustedWidth != canvasWidth || adjustedHeight != canvasHeight)
             {
-                var size = width * height;
+                var size = adjustedWidth * adjustedHeight;
                 canvasColors = new Color32[size];
-                frameRowStart = new int[height];
-                frameRowEnd = new int[height];
+                frameRowStart = new int[adjustedHeight];
+                frameRowEnd = new int[adjustedHeight];
                 revertDisposalBuffer = null;
 
-                canvasWidth = width;
-                canvasHeight = height;
+                canvasWidth = adjustedWidth;
+                canvasHeight = adjustedHeight;
             }
 
             Reset();
@@ -113,13 +116,13 @@ namespace ThreeDISevenZeroR.UnityGifDecoder
         /// <param name="transparentColorIndex">Index of transparent color, color from this index will be treated as transparent</param>
         /// <param name="isInterlaced">Apply deinterlacing during drawing</param>
         /// <param name="disposalMethod">Specifies, how to handle this frame when next frame is drawn</param>
-        public void BeginNewFrame(int x, int y, int width, int height, Color32[] palette, 
+        public void BeginNewFrame(int x, int y, int width, int height, Color32[] palette,
             int transparentColorIndex, bool isInterlaced, GifDisposalMethod disposalMethod)
         {
             switch (frameDisposalMethod)
             {
                 case GifDisposalMethod.ClearToBackgroundColor:
-                    FillWithColor(frameX, frameY, frameWidth, frameHeight, 
+                    FillWithColor(frameX, frameY, frameWidth, frameHeight,
                         new Color32(BackgroundColor.r, BackgroundColor.g, BackgroundColor.b, 0));
 
                     break;
@@ -173,13 +176,23 @@ namespace ThreeDISevenZeroR.UnityGifDecoder
                 frameCanvasPosition = frameRowStart[frameRowCurrent];
                 frameCanvasRowEndPosition = frameRowEnd[frameRowCurrent];
             }
-            
-            if (color != frameTransparentColorIndex)
-                canvasColors[frameCanvasPosition] = framePalette[color];
+
+            if (frameCanvasPosition < canvasColors.Length &&
+                (frameCanvasPosition - frameRowStart[frameRowCurrent]) < frameWidth &&
+                (canvasColors.Length - frameCanvasPosition) >= (canvasWidth - frameWidth))
+            {
+                if (color != frameTransparentColorIndex)
+                    canvasColors[frameCanvasPosition] = framePalette[color];
+            }
+            else
+            {
+                // Fill with white color
+                canvasColors[frameCanvasPosition] = new Color32(255, 255, 255, 255);
+            }
 
             frameCanvasPosition++;
         }
-        
+
         /// <summary>
         /// Fill specified region with single color
         /// </summary>

--- a/Assets/Scripts/Runtime/GifStream.cs
+++ b/Assets/Scripts/Runtime/GifStream.cs
@@ -239,12 +239,17 @@ namespace ThreeDISevenZeroR.UnityGifDecoder
             firstFrameStartPosition = -1;
             currentStream.Read(headerBuffer, 0, headerBuffer.Length);
 
-            if(BitUtils.CheckString(headerBuffer, "GIF87a")) 
+            if(BitUtils.CheckString(headerBuffer, "GIF87a"))
                 header.version = GifVersion.Gif87a;
             else if (BitUtils.CheckString(headerBuffer, "GIF89a"))
                 header.version = GifVersion.Gif89a;
+            else if (BitUtils.CheckString(headerBuffer, "RIFF"))
+                header.version = GifVersion.RIFF;
             else
+            {
                 throw new ArgumentException("Invalid or corrupted Gif file");
+            }
+
 
             // Screen descriptor
             header.width = currentStream.ReadInt16LittleEndian();

--- a/Assets/Scripts/Runtime/Model/GifHeader.cs
+++ b/Assets/Scripts/Runtime/Model/GifHeader.cs
@@ -11,5 +11,21 @@
         public bool sortColors;
         public int colorResolution;
         public int pixelAspectRatio;
+
+        public int adjustedWidth
+        {
+            get
+            {
+                return width + ((4 - (width % 4)) % 4);
+            }
+        }
+
+        public int adjustedHeight
+        {
+            get
+            {
+                return height + ((4 - (height % 4)) % 4);
+            }
+        }
     }
 }

--- a/Assets/Scripts/Runtime/Model/GifVersion.cs
+++ b/Assets/Scripts/Runtime/Model/GifVersion.cs
@@ -6,10 +6,15 @@
         /// Gif specification from year 1989
         /// </summary>
         Gif89a,
-            
+
         /// <summary>
         /// Gif specification from year 1987
         /// </summary>
-        Gif87a
+        Gif87a,
+
+        /// <summary>
+        /// Gif with RIFF format
+        /// </summary>
+        RIFF
     }
 }

--- a/Assets/Scripts/Runtime/Utils/BitUtils.cs
+++ b/Assets/Scripts/Runtime/Utils/BitUtils.cs
@@ -8,9 +8,10 @@ namespace ThreeDISevenZeroR.UnityGifDecoder.Utils
     {
         public static bool CheckString(byte[] array, string s)
         {
+            var stringLength = s.Length;
             for (var i = 0; i < array.Length; i++)
             {
-                if (array[i] != s[i])
+                if (stringLength > i && array[i] != s[i])
                     return false;
             }
 


### PR DESCRIPTION
## What does this PR change?

Added fallback for nonpower of 2 gifs with white pixels at the edges.

Also added a non-standard gif format.

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Test it in the corresponding PR in the explorer repository

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
